### PR TITLE
Works For Me - macOS version

### DIFF
--- a/server.sh
+++ b/server.sh
@@ -3,6 +3,6 @@
 while true ;
 do
 
-	./genhtml.sh data/dump.csv | nc -l -p 2001
+	./genhtml.sh data/dump.csv | nc -l 2001
 
 done


### PR DESCRIPTION
Fixed the bash command to be compatible with macOS. ‘nc’ on mac accepts only the ‘-l’ parameter.